### PR TITLE
E8S Opener and Tea + Troub Opener

### DIFF
--- a/XIVOpeners/Jobs/BRD.lua
+++ b/XIVOpeners/Jobs/BRD.lua
@@ -26,7 +26,7 @@ xivopeners_brd.openerAbilities = {
 }
 
 xivopeners_brd.openerInfo = {
-    listOpeners = {"Recommended", "E8s", "TEA", "No Ninja", "Compatibility"},
+    listOpeners = {"Recommended", "E8s", "TEA", "TEA Troubadour", "No Ninja", "Compatibility"},
 }
 
 xivopeners_brd.openers = {

--- a/XIVOpeners/Jobs/BRD.lua
+++ b/XIVOpeners/Jobs/BRD.lua
@@ -17,6 +17,7 @@ xivopeners_brd.openerAbilities = {
     WanderersMinuet = ActionList:Get(1, 3559),
     BattleVoice = ActionList:Get(1, 118),
     PitchPerfect = ActionList:Get(1, 7404),
+	Troubadour = ActionList:Get(1,7405),
     StraightShotReadyBuffID = 122,
     RagingStrikesBuffID = 125,
     BarrageBuffID = 128,
@@ -25,7 +26,7 @@ xivopeners_brd.openerAbilities = {
 }
 
 xivopeners_brd.openerInfo = {
-    listOpeners = {"Recommended", "TEA", "No Ninja", "Compatibility"},
+    listOpeners = {"Recommended", "E8s", "TEA", "No Ninja", "Compatibility"},
 }
 
 xivopeners_brd.openers = {
@@ -48,6 +49,30 @@ xivopeners_brd.openers = {
 --        xivopeners_brd.openerAbilities.BurstShot, -- this is going to get inserted if we don't get the RA proc
         xivopeners_brd.openerAbilities.Bloodletter,
         xivopeners_brd.openerAbilities.IronJaws,
+		xivopeners_brd.openerAbilities.BurstShot,
+        xivopeners_brd.openerAbilities.EmpyrealArrow
+    },
+	
+	e8s = {
+        xivopeners_brd.openerAbilities.Tincture,
+        xivopeners_brd.openerAbilities.RagingStrikes,
+        xivopeners_brd.openerAbilities.Stormbite,
+		xivopeners_brd.openerAbilities.WanderersMinuet,
+		xivopeners_brd.openerAbilities.BattleVoice,
+		xivopeners_brd.openerAbilities.CausticBite,
+		xivopeners_brd.openerAbilities.EmpyrealArrow,
+        xivopeners_brd.openerAbilities.Bloodletter,	-- after this point it's either 3 burst shots, or RA procs if we get them
+        xivopeners_brd.openerAbilities.BurstShot,
+        xivopeners_brd.openerAbilities.BurstShot,
+        xivopeners_brd.openerAbilities.BurstShot,
+        xivopeners_brd.openerAbilities.RefulgentArrow, -- this will be dequeued if we don't have straight shot ready
+        xivopeners_brd.openerAbilities.Barrage, -- need a check here for an RA proc, and use that instead
+        xivopeners_brd.openerAbilities.RefulgentArrow,
+        xivopeners_brd.openerAbilities.Sidewinder,
+--        xivopeners_brd.openerAbilities.BurstShot, -- this is going to get inserted if we don't get the RA proc
+        xivopeners_brd.openerAbilities.IronJaws,
+		xivopeners_brd.openerAbilities.Bloodletter,
+		xivopeners_brd.openerAbilities.BurstShot,
         xivopeners_brd.openerAbilities.EmpyrealArrow
     },
 
@@ -62,6 +87,29 @@ xivopeners_brd.openers = {
         xivopeners_brd.openerAbilities.BattleVoice, -- after this point it's either 3 burst shots, or RA procs if we get them
         xivopeners_brd.openerAbilities.BurstShot,
         xivopeners_brd.openerAbilities.BurstShot,
+        xivopeners_brd.openerAbilities.BurstShot,
+        xivopeners_brd.openerAbilities.RefulgentArrow, -- this will be dequeued if we don't have straight shot ready
+        xivopeners_brd.openerAbilities.Barrage, -- need a check here for an RA proc, and use that instead
+        xivopeners_brd.openerAbilities.BurstShot,
+--        xivopeners_brd.openerAbilities.Sidewinder, -- skipping this to use at AOE
+--        xivopeners_brd.openerAbilities.BurstShot, -- this is going to get inserted if we don't get the RA proc
+        xivopeners_brd.openerAbilities.Bloodletter,
+        xivopeners_brd.openerAbilities.IronJaws,
+        xivopeners_brd.openerAbilities.EmpyrealArrow
+    },
+	
+	teatroubadour = {
+        xivopeners_brd.openerAbilities.Tincture,
+        xivopeners_brd.openerAbilities.RagingStrikes,
+        xivopeners_brd.openerAbilities.Stormbite,
+        xivopeners_brd.openerAbilities.Bloodletter,
+        xivopeners_brd.openerAbilities.WanderersMinuet,
+        xivopeners_brd.openerAbilities.CausticBite,
+        xivopeners_brd.openerAbilities.EmpyrealArrow,
+        xivopeners_brd.openerAbilities.BattleVoice, -- after this point it's either 3 burst shots, or RA procs if we get them
+        xivopeners_brd.openerAbilities.BurstShot,
+        xivopeners_brd.openerAbilities.BurstShot,
+		xivopeners_brd.openerAbilities.Troubadour,
         xivopeners_brd.openerAbilities.BurstShot,
         xivopeners_brd.openerAbilities.RefulgentArrow, -- this will be dequeued if we don't have straight shot ready
         xivopeners_brd.openerAbilities.Barrage, -- need a check here for an RA proc, and use that instead
@@ -137,11 +185,15 @@ end
 function xivopeners_brd.getOpener()
     if (xivopeners.settings[Player.job].currentOpenerIndex == 1) then
         return xivopeners_brd.openers.recommended
-    elseif (xivopeners.settings[Player.job].currentOpenerIndex == 2) then
-        return xivopeners_brd.openers.tea
+	elseif (xivopeners.settings[Player.job].currentOpenerIndex == 2) then
+        return xivopeners_brd.openers.e8s
     elseif (xivopeners.settings[Player.job].currentOpenerIndex == 3) then
+        return xivopeners_brd.openers.tea
+	elseif (xivopeners.settings[Player.job].currentOpenerIndex == 4) then
+        return xivopeners_brd.openers.teatroubadour
+    elseif (xivopeners.settings[Player.job].currentOpenerIndex == 5) then
         return xivopeners_brd.openers.nonin
-    elseif (xivopeners.settings[Player.job].currentOpenerIndex == 4) then
+    elseif (xivopeners.settings[Player.job].currentOpenerIndex == 6) then
         return xivopeners_brd.openers.compatibility
     end
 end


### PR DESCRIPTION
Adds E8S Opener and a Tea Opener that includes Troub to cover the first AOE which can't be handled with Reaction as XIV is still having controll at that point.